### PR TITLE
Fixed certbot-auto deprecation

### DIFF
--- a/C2concealer/components/dnsoptions.py
+++ b/C2concealer/components/dnsoptions.py
@@ -75,7 +75,8 @@ class dnsOptions(object):
 		'''
 
 		profileString = ''
+		profileString += 'dns-beacon {\n'
 		for attr, value in self.__dict__.items():
-			profileString += 'set ' + attr + ' "' + value + '";\n'
-		profileString += '\n'
+			profileString += '\tset ' + attr + ' "' + value + '";\n'
+		profileString += '}\n\n'
 		return profileString 

--- a/C2concealer/generate-cert.sh
+++ b/C2concealer/generate-cert.sh
@@ -97,12 +97,13 @@ func_apache_check(){
 }
 
 func_install_letsencrypt(){
-  echo '[Starting] cloning into letsencrypt!'
-  git clone https://github.com/certbot/certbot /opt/letsencrypt
+   echo '[Starting] snap install certbot'
+   snap install --classic certbot
+   echo '[Starting] link certbot'
+   sudo ln -s /snap/bin/certbot /usr/bin/certbot
   echo '[Success] letsencrypt is built!'
-  cd /opt/letsencrypt
   echo '[Starting] to build letsencrypt cert!'
-  ./letsencrypt-auto --apache -d $domain -n --register-unsafely-without-email --agree-tos 
+  certbot --apache -d $domain -n --register-unsafely-without-email --agree-tos 
   if [ -e /etc/letsencrypt/live/$domain/fullchain.pem ]; then
     echo '[Success] letsencrypt certs are built!'
     service apache2 stop


### PR DESCRIPTION
We've grown to like C2concealer and use it for engagements all the time, so first of all thank you for that!
As per https://github.com/certbot/certbot/issues/8535 they've deprecated certbot-auto, which breaks the bash script. This has been noticed and some fixes can be seen in projects such as https://github.com/killswitch-GUI/CobaltStrike-ToolKit/pull/8/files. I've kind of stolen that code to fix it here as well. I tested it on a fresh Ubuntu 20.04 box and it appears to work fine now.